### PR TITLE
fixed a syntax error in mono-module.js

### DIFF
--- a/vendors/frida-mono-api/mono-module.js
+++ b/vendors/frida-mono-api/mono-module.js
@@ -5,7 +5,7 @@ let monoModule = null;
 
 // Look for a known runtime module.
 for (let x in KNOWN_RUNTIMES) {
-    let foundModule = Process.findModuleByName(x);
+    let foundModule = Process.findModuleByName(KNOWN_RUNTIMES[x]);
     if (foundModule) {
         monoModule = foundModule;
         break;


### PR DESCRIPTION
Hello @tijme, 

- What does this PR change? 

A minor syntax error fix that would make the mono-module.js to find the mono-module if its one of `KNOWN_RUNTIMES`. which was not working as intended and would just fail all the time and jump to further blocks.